### PR TITLE
Update Github Cheatsheet Link

### DIFF
--- a/part-2-push-your-app-to-github.md
+++ b/part-2-push-your-app-to-github.md
@@ -115,6 +115,6 @@ git push origin master
 #### Learn more Git <a id="learn-more-git"></a>
 
 * Check out [trygit.org](http://try.github.io/)
-* Use a [Git Cheatsheet](https://services.github.com/kit/downloads/github-git-cheat-sheet.pdf)
+* Use a [Git Cheatsheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf)
 * Look up Git Commands at [git-scm.org](http://git-scm.com/)
 


### PR DESCRIPTION
Github cheatsheet link was a 404 error. This new link sends the user to the correct file.